### PR TITLE
Sass lint

### DIFF
--- a/config/.sass-lint.yml
+++ b/config/.sass-lint.yml
@@ -1,0 +1,514 @@
+# Not yet supported by sass-lint:
+# ChainedClasses, DisableLinterReason, ElsePlacement, PropertyCount
+# PseudoElement, SelectorDepth, SpaceAroundOperator, TrailingWhitespace
+# UnnecessaryParentReference, Compass::*
+#
+# The following settings/values are unsupported by sass-lint:
+# Linter Comment, option "style"
+# Linter Indentation, option "allow_non_nested_indentation"
+# Linter Indentation, option "character"
+# Linter NestingDepth, option "ignore_parent_selectors"
+# Linter SpaceBeforeBrace, option "allow_single_line_padding"
+
+files:
+  include: '**/*.s+(a|c)ss'
+options:
+  formatter: stylish
+  merge-default-rules: true
+rules:
+
+  # Rule bem-depth will enforce how many elements a BEM selector can contain.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/bem-depth.md
+  bem-depth: 0
+
+  # Rule border-zero will enforce whether one should use 0 or none when specifying a zero border value
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/border-zero.md
+  border-zero: 2
+
+  # Rule brace-style will enforce the use of the chosen brace style.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/brace-style.md
+  brace-style:
+    - 2
+    - allow-single-line: false
+
+  # Rule class-name-format will enforce a convention for class names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/class-name-format.md#example-7
+  # will allow .block {}, .block__element{}, .block--modifier {}
+  class-name-format:
+    - 2
+    - convention: hyphenatedbem
+
+  # Rule clean-import-paths will enforce whether or not @import paths should have leading underscores and/or filename extensions.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/clean-import-paths.md
+  clean-import-paths:
+    - 2
+    - filename-extension: false
+      leading-underscore: false
+
+  # TODO: empty-args
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/empty-args.md
+
+  # Rule empty-line-between-blocks will enforce whether or not nested blocks should include a space between the last non-comment declaration or not.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/empty-line-between-blocks.md
+  empty-line-between-blocks:
+    - 2
+    - ignore-single-line-rulesets: true
+
+  # Rule extends-before-declarations will enforce that extends should be written before declarations in a ruleset.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/extends-before-declarations.md
+  extends-before-declarations: 0
+
+  # Rule extends-before-mixins will enforce that extends should be written before mixins in a ruleset.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/extends-before-mixins.md
+  extends-before-mixins: 0
+
+  # Rule final-newline will enforce whether or not files should end with a newline.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/final-newline.md
+  final-newline:
+    - 2
+    - include: true
+
+  # Rule force-attribute-nesting will enforce the nesting of attributes
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/force-attribute-nesting.md
+  force-attribute-nesting:
+    - 0
+
+  # Rule force-element-nesting will enforce the nesting of elements
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/force-element-nesting.md
+  force-element-nesting:
+    - 0
+
+  # Rule force-pseudo-nesting will enforce the nesting of pseudo elements/classes.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/force-pseudo-nesting.md
+  force-pseudo-nesting:
+    - 0
+
+  # Rule function-name-format will enforce a convention for function names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/function-name-format.md
+  function-name-format:
+    - 2
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+
+  # Rule hex-length will enforce the length of hexadecimal values
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/hex-length.md
+  hex-length:
+    - 2
+    - style: long
+
+  # Rule hex-notation will enforce the case of hexadecimal values
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/hex-notation.md
+  hex-notation:
+    - 2
+    - style: lowercase
+
+  # Rule id-name-format will enforce a convention for ids.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/id-name-format.md
+  id-name-format:
+    - 2
+    - convention: hyphenatedlowercase
+
+  # Rule indentation will enforce an indentation size (tabs and spaces) and it will also ensure that tabs and spaces are not mixed.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/indentation.md
+  indentation:
+    - 2
+    - size: 2
+
+  # Rule leading-zero will enforce whether or not decimal numbers should include a leading zero.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/leading-zero.md
+  leading-zero:
+    - 2
+    - include: false
+
+  # Rule mixin-name-format will enforce a convention for mixin names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/mixin-name-format.md
+  mixin-name-format:
+    - 2
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+
+  # Rule mixins-before-declarations will enforce that mixins should be written before declarations in a ruleset.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/mixins-before-declarations.md
+  mixins-before-declarations: 0
+
+  # Rule nesting-depth will enforce how deeply a selector can be nested.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/nesting-depth.md
+  nesting-depth:
+    - 2
+    - max-depth: 3
+
+  # TODO: no-attribute-selectors
+  # Rule no-attribute-selectors will warn against the use of attribute selectors.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-attribute-selectors.md
+
+  # TODO: no-colour-hex
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-color-hex.md
+
+  # Rule no-color-keywords will enforce the use of hexadecimal color values rather than literals.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-color-keywords.md
+  no-color-keywords: 2
+
+  # Rule no-color-literals will disallow the use of color literals and basic color functions in any declarations other than variables or maps/lists.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-color-literals.md
+  no-color-literals:
+    - 2
+    - allow-rgba: true
+
+  # TODO: no-combniators
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-combinators.md
+
+  # Rule no-css-comments will enforce the use of Sass single-line comments and disallow CSS comments. Bang comments (/*! */, will be printed even in minified mode) are still allowed.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-css-comments.md
+  no-css-comments: 2
+
+  # Rule no-debug will enforce that @debug statements are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-debug.md
+  no-debug: 2
+
+  # TODO: no-disallowed-properties
+  # Rule no-disallowed-properties will warn against the use of certain properties.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-disallowed-properties.md
+
+  # Rule no-duplicate-properties will enforce that duplicate properties are not allowed within the same block.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-duplicate-properties.md
+  no-duplicate-properties: 2
+
+  # Rule no-empty-rulesets will enforce that rulesets are not empty.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-empty-rulesets.md
+  no-empty-rulesets: 2
+
+  # Rule no-extends will enforce that @extend is not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-extends.md
+  no-extends: 0
+
+  # Rule no-ids will enforce that ID selectors are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-ids.md
+  no-ids: 2
+
+  # Rule no-important will enforce that important declarations are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-important.md
+  no-important: 0
+
+  # Rule no-invalid-hex will enforce that only valid of hexadecimal values are written.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-invalid-hex.md
+  no-invalid-hex: 2
+
+  # Rule no-mergeable-selectors will enforce that selectors aren't repeated and that their properties are merged.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-mergeable-selectors.md
+  no-mergeable-selectors: 0
+
+  # Rule no-misspelled-properties will enforce the correct spelling of CSS properties and prevent the use of unknown CSS properties.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-misspelled-properties.md
+  no-misspelled-properties: 2
+
+  # Rule no-qualifying-elements will enforce that selectors are not allowed to have qualifying elements.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-qualifying-elements.md
+  no-qualifying-elements:
+    - 2
+    - allow-element-with-attribute: true
+      allow-element-with-class: false
+      allow-element-with-id: false
+
+  # TODO: no-trailing-whitespace
+  # Rule no-trailing-whitespace will enforce that trailing whitespace is not allowed.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-trailing-whitespace.md
+
+  # Rule no-trailing-zero will enforce that trailing zeros are not allowed.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-trailing-zero.md
+  no-trailing-zero: 2
+
+  # Rule no-transition-all will enforce whether the keyword all can be used with the transition or transition-property property.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-transition-all.md
+  no-transition-all: 2
+
+  # TODO: no-universal-selectors
+  # Rule no-universal-selectors will warn against the use of * (universal) selectors.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-universal-selectors.md
+
+  # Rule no-url-protocols will enforce that protocols and domains are not used within urls.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-url-protocols.md
+  no-url-protocols: 2
+
+  # Rule no-vendor-prefixes will enforce that vendor prefixes are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-vendor-prefixes.md
+  no-vendor-prefixes: 0
+
+  # Rule no-warn will enforce that @warn statements are not allowed to be used.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/no-warn.md
+  no-warn: 0
+
+  # Rule placeholder-in-extend will enforce whether extends should only include placeholder selectors.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/placeholder-in-extend.md
+  placeholder-in-extend: 0 # govuk-frontend default: 2
+
+  # Rule placeholder-name-format will enforce a convention for placeholder names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/placeholder-name-format.md
+  placeholder-name-format:
+    - 2
+    - convention: hyphenatedlowercasehave 
+
+  # Rule property-sort-order will enforce the order in which declarations are written.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/property-sort-order.md
+  property-sort-order:
+    - 2
+    - order:
+        - 'content'
+        - 'quotes'
+        # Box-sizing - Allow here until global is decided
+        - 'box-sizing'
+        -
+        - 'display'
+        - 'visibility'
+        -
+        - 'position'
+        - 'z-index'
+        - 'top'
+        - 'right'
+        - 'bottom'
+        - 'left'
+        -
+        - 'width'
+        - 'min-width'
+        - 'max-width'
+        - 'height'
+        - 'min-height'
+        - 'max-height'
+        -
+        - 'margin'
+        - 'margin-top'
+        - 'margin-right'
+        - 'margin-bottom'
+        - 'margin-left'
+        -
+        - 'padding'
+        - 'padding-top'
+        - 'padding-right'
+        - 'padding-bottom'
+        - 'padding-left'
+        -
+        - 'float'
+        - 'clear'
+        -
+        - 'overflow'
+        - 'overflow-x'
+        - 'overflow-y'
+        -
+        - 'clip'
+        - 'clip-path'
+        - 'zoom'
+        - 'resize'
+        -
+        - 'columns'
+        -
+        - 'table-layout'
+        - 'empty-cells'
+        - 'caption-side'
+        - 'border-spacing'
+        - 'border-collapse'
+        -
+        - 'list-style'
+        - 'list-style-position'
+        - 'list-style-type'
+        - 'list-style-image'
+        -
+        - 'transform'
+        - 'transition'
+        - 'animation'
+        -
+        - 'border'
+        - 'border-top'
+        - 'border-right'
+        - 'border-bottom'
+        - 'border-left'
+        -
+        - 'border-width'
+        - 'border-top-width'
+        - 'border-right-width'
+        - 'border-bottom-width'
+        - 'border-left-width'
+        -
+        - 'border-style'
+        - 'border-top-style'
+        - 'border-right-style'
+        - 'border-bottom-style'
+        - 'border-left-style'
+        -
+        - 'border-radius'
+        - 'border-top-left-radius'
+        - 'border-top-right-radius'
+        - 'border-bottom-left-radius'
+        - 'border-bottom-right-radius'
+        -
+        - 'border-color'
+        - 'border-top-color'
+        - 'border-right-color'
+        - 'border-bottom-color'
+        - 'border-left-color'
+        -
+        - 'outline'
+        - 'outline-color'
+        - 'outline-offset'
+        - 'outline-style'
+        - 'outline-width'
+        -
+        - 'opacity'
+        # Color has been moved to ensure it appears before background
+        - 'color'
+        - 'background'
+        - 'background-color'
+        - 'background-image'
+        - 'background-repeat'
+        - 'background-position'
+        - 'background-size'
+        - 'box-shadow'
+        - 'fill'
+        -
+        - 'font'
+        - 'font-family'
+        - 'font-size'
+        - 'font-style'
+        - 'font-variant'
+        - 'font-weight'
+        -
+        - 'font-emphasize'
+        -
+        - 'letter-spacing'
+        - 'line-height'
+        - 'list-style'
+        - 'word-spacing'
+        -
+        - 'text-align'
+        - 'text-align-last'
+        - 'text-decoration'
+        - 'text-indent'
+        - 'text-justify'
+        - 'text-overflow'
+        - 'text-overflow-ellipsis'
+        - 'text-overflow-mode'
+        - 'text-rendering'
+        - 'text-outline'
+        - 'text-shadow'
+        - 'text-transform'
+        - 'text-wrap'
+        - 'word-wrap'
+        - 'word-break'
+        -
+        - 'text-emphasis'
+        -
+        - 'vertical-align'
+        - 'white-space'
+        - 'word-spacing'
+        - 'hyphens'
+        -
+        - 'src'
+        - 'cursor'
+        - '-webkit-appearance'
+
+  # Rule property-units will disallow the use of units not specified in global or per-property.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/property-units.md
+  property-units:
+    - 2
+    - global: [
+        'cm',
+        'em',
+        'pt',
+        'px',
+        'rem',
+        'vh',
+        'ex'
+      ]
+
+  # Rule pseudo-element will enforce that:
+  # - pseudo-elements must start with double colons
+  # - pseudo-classes must start with single colon
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/pseudo-element.md
+  pseudo-element:
+    - 0
+
+  # Rule quotes will enforce whether single quotes ('') or double quotes ("") should be used for all strings.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/quotes.md
+  quotes:
+    - 2
+    - style: double
+
+  # Rule shorthand-values will enforce that values in their shorthand form are as concise as specified.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/shorthand-values.md
+  shorthand-values:
+    - 0
+    - allowed-shorthands:
+        - 1
+        - 2
+        - 3
+
+  # Rule single-line-per-selector will enforce whether selectors should be placed on a new line.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/single-line-per-selector.md
+  single-line-per-selector: 2
+
+  # Rule space-after-bang will enforce whether or not a space should be included after a bang (!).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-after-bang.md
+  space-after-bang:
+    - 2
+    - include: false
+
+  # Rule space-after-colon will enforce whether or not a space should be included after a colon (:).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-after-colon.md
+  space-after-colon:
+    - 2
+    - include: true
+
+  # Rule space-after-comma will enforce whether or not a space should be included after a comma (,).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-after-comma.md
+  space-after-comma:
+    - 2
+    - include: true
+
+  # Rule space-around-operator will enforce whether or not a single space should be included before and after the following operators: +, -, /, *, %, <, > ==, !=, <= and >=.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-around-operator.md
+  space-around-operator:
+    - 2
+    - include: true
+
+  # Rule space-before-bang will enforce whether or not a space should be included before a bang (!).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-before-bang.md
+  space-before-bang:
+    - 2
+    - include: true
+
+  # Rule space-before-brace will enforce whether or not a space should be included before a brace ({).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-before-brace.md
+  space-before-brace:
+    - 2
+    - include: true
+
+  # Rule space-before-colon will enforce whether or not a space should be included before a colon (:).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-before-colon.md
+  space-before-colon: 2
+
+  # Rule space-between-parens will enforce whether or not a space should be included before the first item and after the last item inside parenthesis (()).
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/space-between-parens.md
+  space-between-parens: 2
+
+  # Rule trailing-semicolon will enforce whether the last declaration in a block should include a semicolon (;) or not.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/trailing-semicolon.md
+  trailing-semicolon: 2
+
+  # Rule url-quotes will enforce that URLs are wrapped in quotes.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/url-quotes.md
+  url-quotes: 2
+
+  # Rule variable-for-property will enforce the use of variables for the values of specified properties.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/variable-for-property.md
+  variable-for-property:
+    - 0
+    - properties: []
+
+  # Rule variable-name-format will enforce a convention for variable names.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/variable-name-format.md
+  variable-name-format:
+    - 2
+    - allow-leading-underscore: true
+      convention: hyphenatedlowercase
+
+  # Rule zero-unit will enforce whether or not values of 0 used for length should be unitless.
+  # https://github.com/sasstools/sass-lint/blob/master/docs/rules/zero-unit.md
+  zero-unit: 2

--- a/config/paths.json
+++ b/config/paths.json
@@ -1,4 +1,5 @@
 {
   "dist": "dist/",
-  "src": "src/smbc/"
+  "src": "src/smbc/",
+  "config": "config/"
 }

--- a/src/smbc/all-ie8.scss
+++ b/src/smbc/all-ie8.scss
@@ -3,4 +3,4 @@
 // rasterizing media queries.
 $govuk-is-ie8: true;
 
-@import 'all';
+@import "all";

--- a/src/smbc/all.scss
+++ b/src/smbc/all.scss
@@ -1,11 +1,11 @@
 $govuk-is-ie8: false !default;
 
 // StockportGovUk Style Overrides
-@import './settings/all';
+@import "./settings/all";
 
 // GovUk Style Import
-@import '../../node_modules/govuk-frontend/govuk/all';
+@import "../../node_modules/govuk-frontend/govuk/all";
 
 // StockportGovUk Style Specific Overrides
-@import './components/all';
-@import './core/all';
+@import "./components/all";
+@import "./core/all";

--- a/src/smbc/all.scss
+++ b/src/smbc/all.scss
@@ -7,5 +7,5 @@ $govuk-is-ie8: false !default;
 @import "../../node_modules/govuk-frontend/govuk/all";
 
 // StockportGovUk Style Specific Overrides
-@import "./components/all";
 @import "./core/all";
+@import "./components/all";

--- a/src/smbc/components/_all.scss
+++ b/src/smbc/components/_all.scss
@@ -1,5 +1,4 @@
-@import 'header';
-@import 'panel';
-@import 'header';
-@import 'footer';
-@import 'tag';
+@import "footer";
+@import "header";
+@import "panel";
+@import "tag";

--- a/src/smbc/components/_footer.scss
+++ b/src/smbc/components/_footer.scss
@@ -1,5 +1,5 @@
-@import '../settings/all';
-@import '../helpers/all';
+@import "../settings/all";
+@import "../helpers/all";
 
 .smbc-footer {
   @extend .govuk-footer; // sass-lint:disable-line placeholder-in-extend
@@ -10,29 +10,29 @@
 .smbc-footer__logo { // sass-lint:disable-line class-name-format
   @extend .govuk-footer__copyright-logo; // sass-lint:disable-line placeholder-in-extend
   @include govuk-media-query($from: mobile) {
-    background-image: govuk-image-url($logo-footer-180x37);
-    background-size: 180px 37px;
     min-width: 180px;
     padding-top: 37px;
+    background-image: govuk-image-url($logo-footer-180x37);
+    background-size: 180px 37px;
     text-align: left;
   }
   @include govuk-media-query($from: desktop) {
-    background-image: govuk-image-url($logo-footer-200x41);
-    background-size: 200px 41px;
     min-width: 200px;
     padding-top: 41px;
+    background-image: govuk-image-url($logo-footer-200x41);
+    background-size: 200px 41px;
   }
 }
 
 .smbc-footer__meta-item-logo { // sass-lint:disable-line class-name-format
   @extend .govuk-footer__meta-item; // sass-lint:disable-line placeholder-in-extend
   @include govuk-media-query($from: mobile) {
-    order: -1;
     width: 100%;
+    order: -1;
   }
 
   @include govuk-media-query($from: desktop) {
-    order: unset;
     width: unset;
+    order: unset;
   }
 }

--- a/src/smbc/components/_header.scss
+++ b/src/smbc/components/_header.scss
@@ -1,40 +1,41 @@
-@import '../helpers/all';
-@import '../settings/all';
+@import "../helpers/all";
+@import "../settings/all";
 
 .smbc-header {
-  @extend .govuk-header; // sass-lint:disable-line placeholder-in-extend
+  @extend .govuk-header;
   background: $govuk-brand-colour;
 }
 
-.smbc-header__container { // sass-lint:disable-line class-name-format
-  @extend .govuk-header__container; // sass-lint:disable-line placeholder-in-extend
-  border-bottom: 10px solid govuk-colour('smbc-teal');
+.smbc-header__container {
+  @extend .govuk-header__container;
+  border-bottom: 10px solid govuk-colour("smbc-teal");
 }
 
-.smbc-header__logo { // sass-lint:disable-line class-name-format
+.smbc-header__logo {
   @include govuk-media-query($from: mobile) {
-    background-image: govuk-image-url($logo-header-180x37);
-    background-size: 180px 37px;
     min-width: 180px;
     padding-top: 37px;
+    background-image: govuk-image-url($logo-header-180x37);
+    background-size: 180px 37px;
 
     &:focus {
       background-image: govuk-image-url($logo-header-180x37);
-    }
+    };
   }
   @include govuk-media-query($from: desktop) {
-    background-image: govuk-image-url($logo-header-200x41);
-    background-size: 200px 41px;
     min-width: 200px;
     padding-top: 41px;
+    background-image: govuk-image-url($logo-header-200x41);
+    background-size: 200px 41px;
 
     &:focus {
       background-image: govuk-image-url($logo-header-200x41);
-    }
+    };
   }
-  background-position: 50% 0;
-  background-repeat: no-repeat;
+
   display: inline-block;
+  background-repeat: no-repeat;
+  background-position: 50% 0;
   text-align: left;
   text-decoration: none;
   white-space: nowrap;

--- a/src/smbc/components/_panel.scss
+++ b/src/smbc/components/_panel.scss
@@ -1,17 +1,17 @@
-@import '../settings/all';
-@import '../helpers/all';
+@import "../settings/all";
+@import "../helpers/all";
 
 .smbc-panel {
-  @extend .govuk-panel; // sass-lint:disable-line placeholder-in-extend
+  @extend .govuk-panel;
 
   border: 0;
-  border-left: 10px solid govuk-colour('smbc-green');
+  border-left: 10px solid govuk-colour("smbc-green");
   text-align: left;
 }
 
 .smbc-panel--confirmation {
-  @extend .govuk-panel--confirmation; // sass-lint:disable-line placeholder-in-extend
+  @extend .govuk-panel--confirmation;
 
-  background-color: govuk-colour('smbc-green-light');
-  color: govuk-colour('smbc-black');
+  color: govuk-colour("smbc-black");
+  background-color: govuk-colour("smbc-green-light");
 }

--- a/src/smbc/components/_tag.scss
+++ b/src/smbc/components/_tag.scss
@@ -1,7 +1,8 @@
-@import '../settings/all';
-@import '../helpers/all';
+@import "../settings/all";
+@import "../helpers/all";
 
 .smbc-tag {
-  @extend .govuk-tag; // sass-lint:disable-line placeholder-in-extend
-  background-color: govuk-colour('smbc-green');
+  @extend .govuk-tag;
+
+  background-color: govuk-colour("smbc-green");
 }

--- a/src/smbc/core/_all.scss
+++ b/src/smbc/core/_all.scss
@@ -1,1 +1,1 @@
-@import 'typography';
+@import "typography";

--- a/src/smbc/core/_typography.scss
+++ b/src/smbc/core/_typography.scss
@@ -1,6 +1,3 @@
-@import "../../../node_modules/govuk-frontend/govuk/settings/all";
-@import "../../../node_modules/govuk-frontend/govuk/helpers/all";
-
 .smbc-body {
   @extend .govuk-body;
   @include govuk-media-query($from: desktop) {

--- a/src/smbc/core/_typography.scss
+++ b/src/smbc/core/_typography.scss
@@ -1,8 +1,8 @@
-@import '../../../node_modules/govuk-frontend/govuk/settings/all';
-@import '../../../node_modules/govuk-frontend/govuk/helpers/all';
+@import "../../../node_modules/govuk-frontend/govuk/settings/all";
+@import "../../../node_modules/govuk-frontend/govuk/helpers/all";
 
 .smbc-body {
-  @extend .govuk-body; // sass-lint:disable-line placeholder-in-extend
+  @extend .govuk-body;
   @include govuk-media-query($from: desktop) {
     line-height: 1.5;
   }

--- a/src/smbc/helpers/_all.scss
+++ b/src/smbc/helpers/_all.scss
@@ -1,2 +1,2 @@
-@import 'colour';
-@import 'font-faces';
+@import "colour";
+@import "font-faces";

--- a/src/smbc/helpers/_colour.scss
+++ b/src/smbc/helpers/_colour.scss
@@ -1,8 +1,8 @@
-@import "../settings/colours-palette";
-
 ////
 /// @group helpers/colour
 ////
+
+@import "../settings/colours-palette";
 
 /// Get colour
 ///

--- a/src/smbc/helpers/_colour.scss
+++ b/src/smbc/helpers/_colour.scss
@@ -1,4 +1,4 @@
-@import '../settings/colours-palette';
+@import "../settings/colours-palette";
 
 ////
 /// @group helpers/colour
@@ -21,7 +21,7 @@
   }
 
   @if not map-has-key($govuk-colours, $colour) {
-    @error 'Unknown colour `#{$colour}`';
+    @error "Unknown colour `#{$colour}`";
   }
 
   @return map-get($govuk-colours, $colour);

--- a/src/smbc/helpers/_font-faces.scss
+++ b/src/smbc/helpers/_font-faces.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/typography
 ////
 
 // Disables linting for this file only

--- a/src/smbc/helpers/_font-faces.scss
+++ b/src/smbc/helpers/_font-faces.scss
@@ -5,7 +5,7 @@
 // Disables linting for this file only
 // sass-lint:disable no-css-comments, no-duplicate-properties, property-sort-order, indentation
 
-@import '../../../node_modules/govuk-frontend/govuk/tools/all';
+@import "../../../node_modules/govuk-frontend/govuk/tools/all";
 
 /// Font Face - Public Sans
 ///
@@ -16,21 +16,21 @@
 
 @mixin _smbc-font-face-public-sans {
   @include govuk-not-ie8 { // In IE8, which cannot render WOFF format, we fall back to system fonts
-    @include govuk-exports('smbc/helpers/font-faces') {
+    @include govuk-exports("smbc/helpers/font-faces") {
       @at-root {
         @font-face {
-          font-family: 'Public Sans';
-          src: govuk-font-url('PublicSans-ExtraBold.woff2') format('woff2'),
-               govuk-font-url('PublicSans-ExtraBold.woff') format('woff');
+          font-family: "Public Sans";
+          src: govuk-font-url("PublicSans-ExtraBold.woff2") format("woff2"),
+               govuk-font-url("PublicSans-ExtraBold.woff") format("woff");
           font-weight: 800;
           font-style: normal;
           font-display: fallback;
         }
 
         @font-face {
-          font-family: 'Public Sans';
-          src: govuk-font-url('PublicSans-Regular.woff2') format('woff2'),
-               govuk-font-url('PublicSans-Regular.woff') format('woff');
+          font-family: "Public Sans";
+          src: govuk-font-url("PublicSans-Regular.woff2") format("woff2"),
+               govuk-font-url("PublicSans-Regular.woff") format("woff");
           font-weight: normal;
           font-style: normal;
           font-display: fallback;

--- a/src/smbc/settings/_all.scss
+++ b/src/smbc/settings/_all.scss
@@ -1,4 +1,4 @@
+@import "assets";
 @import "colours-palette";
 @import "colours-applied";
 @import "typography-font";
-@import "assets";

--- a/src/smbc/settings/_all.scss
+++ b/src/smbc/settings/_all.scss
@@ -1,4 +1,4 @@
-@import 'colours-palette';
-@import 'colours-applied';
-@import 'typography-font';
-@import 'assets';
+@import "colours-palette";
+@import "colours-applied";
+@import "typography-font";
+@import "assets";

--- a/src/smbc/settings/_assets.scss
+++ b/src/smbc/settings/_assets.scss
@@ -4,6 +4,10 @@
 
 $govuk-assets-path: "./assets/";
 
+$govuk-images-path: "#{$govuk-assets-path}images/" !default;
+
+$govuk-fonts-path: "#{$govuk-assets-path}fonts/" !default;
+
 $logo-footer-180x37: "smbc_footer_mobile_logo_180x37.png";
 $logo-footer-200x41: "smbc_footer_desktop_logo_200x41.png";
 $logo-header-180x37: "smbc_header_mobile_logo_180x37.png";

--- a/src/smbc/settings/_assets.scss
+++ b/src/smbc/settings/_assets.scss
@@ -2,9 +2,9 @@
 /// @group settings/assets
 ////
 
-$govuk-images-path: './assets/images/';
+$govuk-assets-path: "./assets/";
 
-$logo-footer-180x37: 'smbc_footer_mobile_logo_180x37.png';
-$logo-footer-200x41: 'smbc_footer_desktop_logo_200x41.png';
-$logo-header-180x37: 'smbc_header_mobile_logo_180x37.png';
-$logo-header-200x41: 'smbc_header_desktop_logo_200x41.png';
+$logo-footer-180x37: "smbc_footer_mobile_logo_180x37.png";
+$logo-footer-200x41: "smbc_footer_desktop_logo_200x41.png";
+$logo-header-180x37: "smbc_header_mobile_logo_180x37.png";
+$logo-header-200x41: "smbc_header_desktop_logo_200x41.png";

--- a/src/smbc/settings/_colours-applied.scss
+++ b/src/smbc/settings/_colours-applied.scss
@@ -2,8 +2,8 @@
 /// @group settings/colours
 ////
 
-@import '../helpers/colour';
+@import "../helpers/colour";
 
-$govuk-brand-colour: govuk-colour('smbc-green');
-$govuk-link-colour: govuk-colour('smbc-green');
-$govuk-link-hover-colour: govuk-colour('smbc-black');
+$govuk-brand-colour: govuk-colour("smbc-green");
+$govuk-link-colour: govuk-colour("smbc-green");
+$govuk-link-hover-colour: govuk-colour("smbc-black");

--- a/src/smbc/settings/_colours-palette.scss
+++ b/src/smbc/settings/_colours-palette.scss
@@ -3,8 +3,8 @@
 ////
 
 $smbc-colours: (
-  'smbc-teal': #00b79b,
-  'smbc-green-light': #ddedeb,
-  'smbc-green': #066,
-  'smbc-black': #0b0c0c
+  "smbc-teal": #00b79b,
+  "smbc-green-light": #ddedeb,
+  "smbc-green": #006666,
+  "smbc-black": #0b0c0c
 );

--- a/src/smbc/settings/_typography-font.scss
+++ b/src/smbc/settings/_typography-font.scss
@@ -2,9 +2,8 @@
 /// @group settings/typography
 ////
 
-$govuk-fonts-path: './assets/fonts/';
-$govuk-font-family: 'Public Sans', Helvetica, Arial, sans-serif;
+$govuk-font-family: "Public Sans", Helvetica, Arial, sans-serif;
 $govuk-font-weight-bold: 800;
 
-@import './helpers/font-faces';
+@import "./helpers/font-faces";
 @include _smbc-font-face-public-sans;

--- a/tasks/gulp/lint.js
+++ b/tasks/gulp/lint.js
@@ -10,7 +10,9 @@ gulp.task('scss:lint', () => {
   return gulp.src([
     configPaths.src + '**/*.scss'
   ])
-    .pipe(sasslint())
+    .pipe(sasslint({
+      configFile: configPaths.config + '.sass-lint.yml'
+    }))
     .pipe(sasslint.format())
     .pipe(sasslint.failOnError())
 })


### PR DESCRIPTION
Add in govuk-frontend sass-linting config
- Add sass-linting config file to config folder
- Fix linting issues throughout application
- Reset $govuk-images-path and $govuk-fonts-path to default values
- Set $govuk-assets-path to "./assets/"