### PR TITLE
feat: table modifiers and width/alignment overrides

### DIFF
--- a/src/components/_all.scss
+++ b/src/components/_all.scss
@@ -1,3 +1,4 @@
+@import "button/index";
 @import "footer/index";
 @import "header/index";
 @import "maps/index";

--- a/src/components/_all.scss
+++ b/src/components/_all.scss
@@ -1,4 +1,5 @@
 @import "button/index";
+@import "file-upload/index";
 @import "footer/index";
 @import "header/index";
 @import "maps/index";

--- a/src/components/_all.scss
+++ b/src/components/_all.scss
@@ -3,6 +3,5 @@
 @import "header/index";
 @import "maps/index";
 @import "panel/index";
-@import "table/index";
 @import "tag/index";
 @import "time-input/index";

--- a/src/components/_all.scss
+++ b/src/components/_all.scss
@@ -2,5 +2,6 @@
 @import "header/index";
 @import "maps/index";
 @import "panel/index";
+@import "table/index";
 @import "tag/index";
 @import "time-input/index";

--- a/src/components/_all.scss
+++ b/src/components/_all.scss
@@ -4,5 +4,6 @@
 @import "header/index";
 @import "maps/index";
 @import "panel/index";
+@import "table/index";
 @import "tag/index";
 @import "time-input/index";

--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -7,6 +7,7 @@
   border: none;  // sass-lint:disable-line border-zero
   color: govuk-colour("blue");
   background: none;
+  box-shadow: unset;
   text-decoration: underline;
   cursor: pointer;
 

--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -1,9 +1,7 @@
 @import "../../settings/all";
 @import "../../helpers/all";
 
-.smbc-button--clear {
-  @extend .govuk-button;
-
+.smbc-button--link {
   margin-bottom: 0;
   padding: 0;
   border: none;  // sass-lint:disable-line border-zero

--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -1,0 +1,19 @@
+@import "../../settings/all";
+@import "../../helpers/all";
+
+.smbc-button--clear {
+  @extend .govuk-button;
+
+  margin-bottom: 0;
+  padding: 0;
+  border: none;  // sass-lint:disable-line border-zero
+  color: govuk-colour("blue");
+  background: none;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover {
+    color: govuk-colour("blue");
+    background-color: unset;  // sass-lint:disable-line border-zero
+  }
+}

--- a/src/components/file-upload/_index.scss
+++ b/src/components/file-upload/_index.scss
@@ -1,0 +1,6 @@
+.smbc-file-upload {
+  @extend .govuk-file-upload;
+
+  width: 100%;
+  text-overflow: ellipsis;
+}

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -1,6 +1,4 @@
 .smbc-table__cell--wrap {
   max-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-all;
 }

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -1,5 +1,0 @@
-.smbc-table {
-  @extend .govuk-table;
-  padding-left: 0;
-  text-align: left;
-  }

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -1,0 +1,6 @@
+.smbc-table__cell--wrap {
+  max-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -1,0 +1,8 @@
+@import "../../settings/all";
+@import "../../helpers/all";
+
+.smbc-table {
+  @extend .govuk-table;
+  padding-left: 0;
+  text-align: left;
+  }

--- a/src/components/table/_index.scss
+++ b/src/components/table/_index.scss
@@ -1,6 +1,3 @@
-@import "../../settings/all";
-@import "../../helpers/all";
-
 .smbc-table {
   @extend .govuk-table;
   padding-left: 0;

--- a/src/overrides/_alignment.scss
+++ b/src/overrides/_alignment.scss
@@ -1,0 +1,5 @@
+@import "../helpers/all";
+
+.smbc-\!-alignment-right {
+  float: right !important;
+}

--- a/src/overrides/_all.scss
+++ b/src/overrides/_all.scss
@@ -1,2 +1,3 @@
 @import "alignment";
 @import "typography";
+@import "width";

--- a/src/overrides/_all.scss
+++ b/src/overrides/_all.scss
@@ -1,1 +1,2 @@
+@import "alignment";
 @import "typography";

--- a/src/overrides/_width.scss
+++ b/src/overrides/_width.scss
@@ -1,0 +1,27 @@
+////
+/// @group overrides
+////
+
+$_width-percentage: (
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+  ) !default;
+
+@mixin _smbc-generate-width-overrides {
+  @each $percentage in $_width-percentage {
+
+    .smbc-\!-width-#{$percentage} {
+      width: #{$percentage}#{"%"};
+    }
+  }
+}
+
+@include _smbc-generate-width-overrides;


### PR DESCRIPTION
### Description
- Added smbc overrides for width from 0 - 100 by increments of 10
- Added button modifier for button-link
- Added table row modifier to allow text to wrap
- Added smbc-file-upload to allow text-overflow ellipsis within file html input
- Added new override for alignment, to allow floating of elements to the right

**new classes and modifiers:**
  -  smbc-file-upload
  -  smbc-table__cell--wrap
  -  smbc-button--link
  -  smbc-!-width-10/20/30/40/50/60/70/80/90/100
  -  smbc-\!-alignment-right

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary