### PR TITLE
fix: change file size calculation to use 1MB binary bytes value

### DIFF
--- a/src/components/file-upload/multiple-file-upload.js
+++ b/src/components/file-upload/multiple-file-upload.js
@@ -22,7 +22,7 @@ MultipleFileUpload.prototype.validateFileSize = function (event) {
   var errorText = '<span class="govuk-visually-hidden"Error:></span> '
   var allValid = true
   var maxFileSize = target.getAttribute('data-individual-file-size')
-  var readableMaxFileSize = (maxFileSize / 1024000).toFixed(0) + 'MB'
+  var readableMaxFileSize = (maxFileSize / 1048576) + 'MB'
 
   for (var index = 0; index < target.files.length; index++) {
     var fileSize = target.files[index].size


### PR DESCRIPTION
### Description
Change max file size check to use bytes binary value for 1MB.

1 MB = 1,048,576 Bytes

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary