### PR TITLE
Disable upload files button

### DIFF
--- a/src/components/file-upload/multiple-file-upload.js
+++ b/src/components/file-upload/multiple-file-upload.js
@@ -73,9 +73,7 @@ MultipleFileUpload.prototype.validateFileSize = function (event) {
 * via the html input
 */
 MultipleFileUpload.prototype.disableButtonOnNoFilesSelected = function (event) {
-  var target = event.target
-
-  this.disabled = target.files.length > 0 
+  this.disabled = event.target.files.length > 0 
     ? this.disabled = false 
     : this.disabled = true
 }

--- a/src/components/file-upload/multiple-file-upload.js
+++ b/src/components/file-upload/multiple-file-upload.js
@@ -14,7 +14,7 @@ function MultipleFileUpload ($module) {
   this.$formGroup = document.getElementById('multiple-file-upload-form-group')
   this.maxFileSize = this.$module.getAttribute('data-individual-file-size')
   this.sizeValidation = document.getElementById(this.$module.id + '-fileSizeError')
-  this.readableMaxFileSize  = (this.maxFileSize / 1048576) + 'MB'
+  this.readableMaxFileSize = (this.maxFileSize / 1048576) + 'MB'
 }
 
 /**
@@ -70,19 +70,18 @@ MultipleFileUpload.prototype.validateFileSize = function (event) {
   }
 }
 
-
 /**
 * Disable the upload files button, when no files have been selected
 * via the html input
 */
 MultipleFileUpload.prototype.disableButtonOnNoFilesSelected = function (event) {
-  if(event.target.files.length > 0 ){
+  if (event.target.files.length > 0) {
     this.$uploadFileButton.disabled = false
-    this.$uploadFileButton.setAttribute("aria-disabled", false)
+    this.$uploadFileButton.setAttribute('aria-disabled', false)
     this.$uploadFileInformation.innerHTML = UPLOAD_FILES_ENABLED_TEXT
   } else {
     this.$uploadFileButton.disabled = true
-    this.$uploadFileButton.setAttribute("aria-disabled", true)
+    this.$uploadFileButton.setAttribute('aria-disabled', true)
     this.$uploadFileInformation.innerHTML = UPLOAD_FILES_DISABLED_TEXT
   }
 }
@@ -91,14 +90,13 @@ MultipleFileUpload.prototype.disableButtonOnNoFilesSelected = function (event) {
  * Initialise an event listener for onchange on the element
  */
 MultipleFileUpload.prototype.init = function () {
-
-  if(this.$uploadFileInformation !== null){
+  this.$module.addEventListener('change', this.validateFileSize.bind(this))
+  if (this.$uploadFileInformation !== null) {
     this.$uploadFileButton.disabled = true
-    this.$uploadFileButton.setAttribute("aria-disabled", true);
+    this.$uploadFileButton.setAttribute('aria-disabled', true)
     this.$uploadFileInformation.innerHTML = UPLOAD_FILES_DISABLED_TEXT
     this.$module.addEventListener('change', this.disableButtonOnNoFilesSelected.bind(this))
   }
-  this.$module.addEventListener('change', this.validateFileSize.bind(this))
 }
 
 export default MultipleFileUpload

--- a/src/components/file-upload/multiple-file-upload.js
+++ b/src/components/file-upload/multiple-file-upload.js
@@ -4,6 +4,8 @@ import 'govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind'
 var INPUT_FILE_ERROR_CLASS = 'smbc-input--file-error'
 var FORM_GROUP_ERROR_CLASS = 'govuk-form-group--error'
 var INPUT_ERROR_CLASS = 'govuk-input--error'
+var UPLOAD_FILES_DISABLED_TEXT = 'Upload button is currently disabled'
+var UPLOAD_FILES_ENABLED_TEXT = 'Upload button is currently enabled'
 
 function MultipleFileUpload ($module) {
   this.$module = $module
@@ -77,11 +79,11 @@ MultipleFileUpload.prototype.disableButtonOnNoFilesSelected = function (event) {
   if(event.target.files.length > 0 ){
     this.$uploadFileButton.disabled = false
     this.$uploadFileButton.setAttribute("aria-disabled", false)
-    this.$uploadFileInformation.innerHTML = "Upload button is currently enabled"
+    this.$uploadFileInformation.innerHTML = UPLOAD_FILES_ENABLED_TEXT
   } else {
     this.$uploadFileButton.disabled = true
     this.$uploadFileButton.setAttribute("aria-disabled", true)
-    this.$uploadFileInformation.innerHTML = "Upload button is currently disabled"
+    this.$uploadFileInformation.innerHTML = UPLOAD_FILES_DISABLED_TEXT
   }
 }
 
@@ -89,11 +91,14 @@ MultipleFileUpload.prototype.disableButtonOnNoFilesSelected = function (event) {
  * Initialise an event listener for onchange on the element
  */
 MultipleFileUpload.prototype.init = function () {
-  this.$uploadFileButton.disabled = true
-  this.$uploadFileButton.setAttribute("aria-disabled", true);
-  this.$uploadFileInformation.innerHTML = "Upload button is currently disabled"
+
+  if(this.$uploadFileInformation !== null){
+    this.$uploadFileButton.disabled = true
+    this.$uploadFileButton.setAttribute("aria-disabled", true);
+    this.$uploadFileInformation.innerHTML = UPLOAD_FILES_DISABLED_TEXT
+    this.$module.addEventListener('change', this.disableButtonOnNoFilesSelected.bind(this))
+  }
   this.$module.addEventListener('change', this.validateFileSize.bind(this))
-  this.$module.addEventListener('change', this.disableButtonOnNoFilesSelected.bind(this))
 }
 
 export default MultipleFileUpload

--- a/src/components/file-upload/multiple-file-upload.js
+++ b/src/components/file-upload/multiple-file-upload.js
@@ -7,6 +7,11 @@ var INPUT_ERROR_CLASS = 'govuk-input--error'
 
 function MultipleFileUpload ($module) {
   this.$module = $module
+  this.$uploadFileButton = document.getElementById('upload')
+  this.$formGroup = document.getElementById('multiple-file-upload-form-group')
+  this.maxFileSize = this.$module.getAttribute('data-individual-file-size')
+  this.sizeValidation = document.getElementById(this.$module.id + '-fileSizeError')
+  this.readableMaxFileSize  = (this.maxFileSize / 1048576) + 'MB'
 }
 
 /**
@@ -15,63 +20,73 @@ function MultipleFileUpload ($module) {
 */
 MultipleFileUpload.prototype.validateFileSize = function (event) {
   var target = event.target
-  var sizeValidation = document.getElementById(target.id + '-fileSizeError')
-  var formGroup = document.getElementById('multiple-file-upload-form-group')
-  var input = document.getElementById(target.id)
   var validation = document.getElementById(target.id + '-error')
   var errorText = '<span class="govuk-visually-hidden"Error:></span> '
   var allValid = true
-  var maxFileSize = target.getAttribute('data-individual-file-size')
-  var readableMaxFileSize = (maxFileSize / 1048576) + 'MB'
 
   for (var index = 0; index < target.files.length; index++) {
     var fileSize = target.files[index].size
 
-    if (fileSize > maxFileSize) {
+    if (fileSize > this.maxFileSize) {
       if (validation !== null) {
         validation.remove()
       }
-      sizeValidation.style.display = 'block'
-      input.setAttribute('aria-describedby', target.id + '-fileSizeError')
-      sizeValidation.setAttribute('style', 'white-space: pre-line;')
+      this.sizeValidation.style.display = 'block'
+      this.$module.setAttribute('aria-describedby', target.id + '-fileSizeError')
+      this.sizeValidation.setAttribute('style', 'white-space: pre-line;')
       if (target.files.length === 1) {
-        errorText += 'The selected file must be smaller than ' + readableMaxFileSize
+        errorText += 'The selected file must be smaller than ' + this.readableMaxFileSize
       } else {
-        errorText += target.files[index].name + ' must be smaller than ' + readableMaxFileSize + '\r\n'
+        errorText += target.files[index].name + ' must be smaller than ' + this.readableMaxFileSize + '\r\n'
       }
       allValid = false
-      formGroup.classList.add(FORM_GROUP_ERROR_CLASS)
+      this.$formGroup.classList.add(FORM_GROUP_ERROR_CLASS)
     }
   }
 
-  sizeValidation.innerHTML = errorText
+  this.sizeValidation.innerHTML = errorText
 
   if (allValid) {
-    sizeValidation.style.display = 'none'
+    this.sizeValidation.style.display = 'none'
     if (validation !== null) {
       validation.remove()
     }
-    input.removeAttribute('aria-describedby')
+    this.$module.removeAttribute('aria-describedby')
 
-    if (input.classList.contains(INPUT_ERROR_CLASS)) {
-      input.classList.remove(INPUT_ERROR_CLASS)
+    if (this.$module.classList.contains(INPUT_ERROR_CLASS)) {
+      this.$module.classList.remove(INPUT_ERROR_CLASS)
     }
 
-    if (input.classList.contains(INPUT_FILE_ERROR_CLASS)) {
-      input.classList.remove(INPUT_FILE_ERROR_CLASS)
+    if (this.$module.classList.contains(INPUT_FILE_ERROR_CLASS)) {
+      this.$module.classList.remove(INPUT_FILE_ERROR_CLASS)
     }
 
-    if (formGroup.classList.contains(FORM_GROUP_ERROR_CLASS)) {
-      formGroup.classList.remove(FORM_GROUP_ERROR_CLASS)
+    if (this.$formGroup.classList.contains(FORM_GROUP_ERROR_CLASS)) {
+      this.$formGroup.classList.remove(FORM_GROUP_ERROR_CLASS)
     }
   }
+}
+
+
+/**
+* Disable the upload files button, when no files have been selected
+* via the html input
+*/
+MultipleFileUpload.prototype.disableButtonOnNoFilesSelected = function (event) {
+  var target = event.target
+
+  this.disabled = target.files.length > 0 
+    ? this.disabled = false 
+    : this.disabled = true
 }
 
 /**
 * Initialise an event listener for onchange on the element
 */
 MultipleFileUpload.prototype.init = function () {
-  this.$module.addEventListener('change', this.validateFileSize)
+  this.$uploadFileButton.disabled = true
+  this.$module.addEventListener('change', this.validateFileSize.bind(this))
+  this.$module.addEventListener('change', this.disableButtonOnNoFilesSelected.bind(this.$uploadFileButton))
 }
 
 export default MultipleFileUpload

--- a/src/components/file-upload/multiple-file-upload.js
+++ b/src/components/file-upload/multiple-file-upload.js
@@ -8,6 +8,7 @@ var INPUT_ERROR_CLASS = 'govuk-input--error'
 function MultipleFileUpload ($module) {
   this.$module = $module
   this.$uploadFileButton = document.getElementById('upload')
+  this.$uploadFileInformation = document.getElementById('upload-information')
   this.$formGroup = document.getElementById('multiple-file-upload-form-group')
   this.maxFileSize = this.$module.getAttribute('data-individual-file-size')
   this.sizeValidation = document.getElementById(this.$module.id + '-fileSizeError')
@@ -73,18 +74,26 @@ MultipleFileUpload.prototype.validateFileSize = function (event) {
 * via the html input
 */
 MultipleFileUpload.prototype.disableButtonOnNoFilesSelected = function (event) {
-  this.disabled = event.target.files.length > 0 
-    ? this.disabled = false 
-    : this.disabled = true
+  if(event.target.files.length > 0 ){
+    this.$uploadFileButton.disabled = false
+    this.$uploadFileButton.setAttribute("aria-disabled", false)
+    this.$uploadFileInformation.innerHTML = "Upload button is currently enabled"
+  } else {
+    this.$uploadFileButton.disabled = true
+    this.$uploadFileButton.setAttribute("aria-disabled", true)
+    this.$uploadFileInformation.innerHTML = "Upload button is currently disabled"
+  }
 }
 
 /**
-* Initialise an event listener for onchange on the element
-*/
+ * Initialise an event listener for onchange on the element
+ */
 MultipleFileUpload.prototype.init = function () {
   this.$uploadFileButton.disabled = true
+  this.$uploadFileButton.setAttribute("aria-disabled", true);
+  this.$uploadFileInformation.innerHTML = "Upload button is currently disabled"
   this.$module.addEventListener('change', this.validateFileSize.bind(this))
-  this.$module.addEventListener('change', this.disableButtonOnNoFilesSelected.bind(this.$uploadFileButton))
+  this.$module.addEventListener('change', this.disableButtonOnNoFilesSelected.bind(this))
 }
 
 export default MultipleFileUpload


### PR DESCRIPTION
### Description
Added disableButtonOnNoFilesSelected eventListner to disable/enable the upload files button when the the user selects no file.

Changed validateFileSize eventListner to bind to this(MultipleFileUpload) instead of $module to allow to access variables within this(MultipleFileUpload)

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary