### PR TITLE
chore(recaptcha): set width to display errors correctly

### DIFF
--- a/src/components/recaptcha/_index.scss
+++ b/src/components/recaptcha/_index.scss
@@ -1,3 +1,4 @@
 .smbc-recaptcha {
+  width: 304px;
   margin-bottom: 30px;
 }


### PR DESCRIPTION
### Description
In order for the error box to display correctly, the size of the recaptcha needs to be set to the same size as the child div


### Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary