### PR TITLE
feat(DIGITAL-3750): JS modules for calendar/time

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -1,5 +1,7 @@
 import { nodeListForEach } from './common'
 import Button from './components/button/button'
+import Calendar from './components/calendar/calendar'
+import Time from './components/time/time'
 import FileUpload from './components/file-upload/file-upload'
 import MultipleFileUpload from './components/file-upload/multiple-file-upload'
 import Recaptcha from './components/recaptcha/recaptcha'
@@ -30,6 +32,16 @@ function initAll (options) {
   var $recaptchas = scope.querySelectorAll('[data-module="smbc-recaptcha"]')
   nodeListForEach($recaptchas, function ($recaptcha) {
     new Recaptcha($recaptcha).init()
+  })
+
+  var $calendars = scope.querySelectorAll('[data-module="smbc-calendar"]')
+  nodeListForEach($calendars, function ($calendar) {
+    new Calendar($calendar).init()
+  })
+
+  var $times = scope.querySelectorAll('[data-module="smbc-time"]')
+  nodeListForEach($times, function ($time) {
+    new Time($time).init()
   })
 }
 

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -1,0 +1,107 @@
+import 'govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind' // addEventListener, event.target normalization and DOMContentLoaded
+import 'govuk-frontend/govuk/vendor/polyfills/Event'
+import 'govuk-frontend/govuk/vendor/polyfills/Element/prototype/classList'
+import { nodeListForEach } from '../../common'
+
+function Calendar ($module) {
+  this.$module = $module
+  this.$inputs = $module.querySelectorAll('input[type="radio"]')
+}
+
+Calendar.prototype.init = function () {
+  var $module = this.$module
+  var $inputs = this.$inputs
+
+  nodeListForEach($inputs, function ($input) {
+    var target = $input.getAttribute('data-aria-controls')
+
+    // Skip radios without data-aria-controls attributes, or where the
+    // target element does not exist.
+    if (!target || !$module.querySelector('#' + target)) {
+      return
+    }
+
+    // Promote the data-aria-controls attribute to a aria-controls attribute
+    // so that the relationship is exposed in the AOM
+    $input.setAttribute('aria-controls', target)
+    $input.removeAttribute('data-aria-controls')
+  })
+
+  // When the page is restored after navigating 'back' in some browsers the
+  // state of form controls is not restored until *after* the DOMContentLoaded
+  // event is fired, so we need to sync after the pageshow event in browsers
+  // that support it.
+  if ('onpageshow' in window) {
+    window.addEventListener('pageshow', this.syncAllConditionalReveals.bind(this))
+  } else {
+    window.addEventListener('DOMContentLoaded', this.syncAllConditionalReveals.bind(this))
+  }
+
+  // Although we've set up handlers to sync state on the pageshow or
+  // DOMContentLoaded event, init could be called after those events have fired,
+  // for example if they are added to the page dynamically, so sync now too.
+  this.syncAllConditionalReveals()
+
+  // Handle events
+  $module.addEventListener('click', this.handleClick.bind(this))
+}
+
+/**
+ * Sync the conditional reveal states for all inputs in this $module.
+ */
+Calendar.prototype.syncAllConditionalReveals = function () {
+  nodeListForEach(this.$inputs, this.syncConditionalRevealWithInputState.bind(this))
+}
+
+/**
+ * Sync conditional reveal with the input state
+ *
+ * Synchronise the visibility of the conditional reveal, and its accessible
+ * state, with the input's checked state.
+ *
+ * @param {HTMLInputElement} $input Radio input
+ */
+Calendar.prototype.syncConditionalRevealWithInputState = function ($input) {
+  var $target = document.querySelector('#' + $input.getAttribute('aria-controls'))
+
+  if ($target && $target.classList.contains('smbc-time__conditional')) {
+    var inputIsChecked = $input.checked
+
+    $input.setAttribute('aria-expanded', inputIsChecked)
+    $target.classList.toggle('smbc-time__conditional--hidden', !inputIsChecked)
+  }
+}
+
+/**
+ * Click event handler
+ *
+ * Handle a click within the $module – if the click occurred on a radio, sync
+ * the state of the conditional reveal for all radio buttons in the same form
+ * with the same name (because checking one radio could have un-checked a radio
+ * in another $module)
+ *
+ * @param {MouseEvent} event Click event
+ */
+Calendar.prototype.handleClick = function (event) {
+  var $clickedInput = event.target
+
+  // Ignore clicks on things that aren't radio buttons
+  if ($clickedInput.type !== 'radio') {
+    return
+  }
+
+  // We only need to consider radios with conditional reveals, which will have
+  // aria-controls attributes.
+  var $allInputs = document.querySelectorAll('input[type="radio"][aria-controls]')
+
+  nodeListForEach($allInputs, function ($input) {
+    var hasSameFormOwner = ($input.form === $clickedInput.form)
+    var hasSameName = ($input.name === $clickedInput.name)
+
+    if (hasSameName && hasSameFormOwner) {
+      this.syncConditionalRevealWithInputState($input)
+    }
+  }.bind(this))
+}
+
+export default Calendar

--- a/src/components/time/_index.scss
+++ b/src/components/time/_index.scss
@@ -11,8 +11,14 @@
   }
 }
 
+.js-enabled {
+  .smbc-time__header {
+    display: flex;
+  }
+} 
+
 .smbc-time__header {
-  display: flex;
+  display: none;
   margin-bottom: govuk-spacing(6);
   flex-direction: row;
   flex-wrap: wrap;

--- a/src/components/time/_index.scss
+++ b/src/components/time/_index.scss
@@ -5,6 +5,12 @@
   width: 344px;
 }
 
+.smbc-time__conditional {
+  .js-enabled &--hidden {
+    display: none;
+  }
+}
+
 .smbc-time__header {
   display: flex;
   margin-bottom: govuk-spacing(6);
@@ -17,6 +23,12 @@
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: space-between;
+}
+
+.smbc-time__body__conditional {
+  .js-enabled &--hidden {
+    display: none;
+  }
 }
 
 .smbc-time__period {

--- a/src/components/time/_index.scss
+++ b/src/components/time/_index.scss
@@ -15,7 +15,7 @@
   .smbc-time__header {
     display: flex;
   }
-} 
+}
 
 .smbc-time__header {
   display: none;

--- a/src/components/time/time.js
+++ b/src/components/time/time.js
@@ -1,0 +1,107 @@
+import 'govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind' // addEventListener, event.target normalization and DOMContentLoaded
+import 'govuk-frontend/govuk/vendor/polyfills/Event'
+import 'govuk-frontend/govuk/vendor/polyfills/Element/prototype/classList'
+import { nodeListForEach } from '../../common'
+
+function Time ($module) {
+  this.$module = $module
+  this.$inputs = $module.querySelectorAll('input[type="radio"]')
+}
+
+Time.prototype.init = function () {
+  var $module = this.$module
+  var $inputs = this.$inputs
+
+  nodeListForEach($inputs, function ($input) {
+    var target = $input.getAttribute('data-aria-controls')
+
+    // Skip radios without data-aria-controls attributes, or where the
+    // target element does not exist.
+    if (!target || !$module.querySelector('#' + target)) {
+      return
+    }
+
+    // Promote the data-aria-controls attribute to a aria-controls attribute
+    // so that the relationship is exposed in the AOM
+    $input.setAttribute('aria-controls', target)
+    $input.removeAttribute('data-aria-controls')
+  })
+
+  // When the page is restored after navigating 'back' in some browsers the
+  // state of form controls is not restored until *after* the DOMContentLoaded
+  // event is fired, so we need to sync after the pageshow event in browsers
+  // that support it.
+  if ('onpageshow' in window) {
+    window.addEventListener('pageshow', this.syncAllConditionalReveals.bind(this))
+  } else {
+    window.addEventListener('DOMContentLoaded', this.syncAllConditionalReveals.bind(this))
+  }
+
+  // Although we've set up handlers to sync state on the pageshow or
+  // DOMContentLoaded event, init could be called after those events have fired,
+  // for example if they are added to the page dynamically, so sync now too.
+  this.syncAllConditionalReveals()
+
+  // Handle events
+  $module.addEventListener('click', this.handleClick.bind(this))
+}
+
+/**
+ * Sync the conditional reveal states for all inputs in this $module.
+ */
+Time.prototype.syncAllConditionalReveals = function () {
+  nodeListForEach(this.$inputs, this.syncConditionalRevealWithInputState.bind(this))
+}
+
+/**
+ * Sync conditional reveal with the input state
+ *
+ * Synchronise the visibility of the conditional reveal, and its accessible
+ * state, with the input's checked state.
+ *
+ * @param {HTMLInputElement} $input Radio input
+ */
+Time.prototype.syncConditionalRevealWithInputState = function ($input) {
+  var $target = document.querySelector('#' + $input.getAttribute('aria-controls'))
+
+  if ($target && $target.classList.contains('smbc-time__body__conditional')) {
+    var inputIsChecked = $input.checked
+
+    $input.setAttribute('aria-expanded', inputIsChecked)
+    $target.classList.toggle('smbc-time__body__conditional--hidden', !inputIsChecked)
+  }
+}
+
+/**
+ * Click event handler
+ *
+ * Handle a click within the $module – if the click occurred on a radio, sync
+ * the state of the conditional reveal for all radio buttons in the same form
+ * with the same name (because checking one radio could have un-checked a radio
+ * in another $module)
+ *
+ * @param {MouseEvent} event Click event
+ */
+Time.prototype.handleClick = function (event) {
+  var $clickedInput = event.target
+
+  // Ignore clicks on things that aren't radio buttons
+  if ($clickedInput.type !== 'radio') {
+    return
+  }
+
+  // We only need to consider radios with conditional reveals, which will have
+  // aria-controls attributes.
+  var $allInputs = document.querySelectorAll('input[type="radio"][aria-controls]')
+
+  nodeListForEach($allInputs, function ($input) {
+    var hasSameFormOwner = ($input.form === $clickedInput.form)
+    var hasSameName = ($input.name === $clickedInput.name)
+
+    if (hasSameName && hasSameFormOwner) {
+      this.syncConditionalRevealWithInputState($input)
+    }
+  }.bind(this))
+}
+
+export default Time


### PR DESCRIPTION
### Description
Added js modules for calendar and time to show and hide divs based on the provided aria-controls attribute on the given element.

Updated and added some css classes to hide elements when JS is enabled/disabled

Have left original govuk comments, but can be removed.

**new classes:**

- smbc-time__conditional
- smbc-time__conditional--hidden
- smbc-time__body__conditional
- smbc-time__body__conditional--hidden


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary