### PR TITLE
fix(time): remove js-enabled parent check on hidden

### DIFF
--- a/src/components/time/_index.scss
+++ b/src/components/time/_index.scss
@@ -5,10 +5,8 @@
   width: 344px;
 }
 
-.smbc-time__conditional {
-  .js-enabled &--hidden {
-    display: none;
-  }
+.smbc-time__conditional--hidden {
+  display: none;
 }
 
 .js-enabled {


### PR DESCRIPTION
### Description
changed display logic for `smbc-time__conditional--hidden` to always be display 'none'

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary