### PR TITLE
style(information): changed icons fontsize

### DIFF
--- a/src/components/information/_index.scss
+++ b/src/components/information/_index.scss
@@ -2,13 +2,14 @@
 @import "../../settings/all";
 
 .smbc-information__icon {
-  @include govuk-font($size: 27);
   display: flex;
   width: 48px;
   height: 48px;
   border-radius: 80px;
   color: govuk-colour("white");
   background-color: govuk-colour("smbc-green");
+  font-size: govuk-px-to-rem(27);
+  line-height: _govuk-line-height(30px, 27px);
   justify-content: center;
   align-items: center;
 }

--- a/src/components/information/_index.scss
+++ b/src/components/information/_index.scss
@@ -9,7 +9,7 @@
   color: govuk-colour("white");
   background-color: govuk-colour("smbc-green");
   font-size: govuk-px-to-rem(27);
-  line-height: _govuk-line-height(30px, 27px);
+  line-height: _govuk-line-height($line-height: 30px, $font-size: 27px);
   justify-content: center;
   align-items: center;
 }


### PR DESCRIPTION
### Description
Update information icons to always be size 27px and not responsive


### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary