### PR TITLE
fet(DIGITAL-4524): styling for popup content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smbc-design-system",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "",
   "main": "gulpfile.js",
   "engines": {

--- a/src/components/maps/_popups.scss
+++ b/src/components/maps/_popups.scss
@@ -38,7 +38,7 @@
     max-width: 270px;
     max-height: 400px;
     margin: 25px 5px 19px 13px;
-    padding-right: 20px;
+    padding: 5px 20px 5px 5px;
     overflow-y: auto;
     line-height: 1.4;
 

--- a/src/components/maps/_popups.scss
+++ b/src/components/maps/_popups.scss
@@ -1,6 +1,33 @@
 @import "../../helpers/all";
 @import "../../settings/all";
 
+.smbc-map__item:not(:first-of-type) {
+  padding-top: 10px;
+}
+
+.smbc-map__item__header__block {
+  display: flex;
+  color:  govuk-colour("light-grey");
+  align-items: center;
+  @include govuk-font($size: 19);
+
+  &__icon {
+    padding-right: 10px;
+  }
+
+  &__title {
+    margin-top: 0;
+    margin-bottom: 0;
+    @include govuk-font($size: 16);
+  }
+}
+
+.smbc-map__item__body {
+  @extend .smbc-body;
+  padding-left: 27px;
+  color: govuk-colour("white");
+}
+
 .leaflet-popup > .leaflet-popup-content-wrapper {
   width: 100%;
   border-radius: 3px;
@@ -8,6 +35,13 @@
   background-color: rgba(0, 0, 0, 0.9); // sass-lint:disable-line no-color-literals leading-zero
 
   .leaflet-popup-content {
+    max-width: 270px;
+    max-height: 400px;
+    margin: 25px 5px 19px 13px;
+    padding-right: 20px;
+    overflow-y: auto;
+    line-height: 1.4;
+
     &:not(:last-of-type) {
       border-bottom: 2px solid govuk-colour("light-grey");
     }
@@ -27,14 +61,6 @@
 
     .info {
       margin-top: 0;
-    }
-
-    .fa {
-      position: absolute;
-      left: 14px;
-      padding-left: 6px;
-      color: govuk-colour("light-grey");
-      line-height: 1.316;
     }
 
     a {


### PR DESCRIPTION
### Description
Added styling to support popup content within mapping solution for multiple items visible

Example struicture of popup
```html
<div class="smbc-map__item">
  <div class="smbc-map__item__header__block">
    <i class="fa fa-list smbc-map__item__header__block__icon" aria-hidden="true"></i>
    <h2 class="smbc-map__item__header__block__title">Item title</h2>
  </div>
  <div class="smbc-map__item__body">
    <p>Name: Test</p>
    <p>Type: Test</p>
    <a href="#" target="_blank">Further Information</a>
  </div>
</div>
```

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary