### PR TITLE
fix(map): added word-break to maps popup content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smbc-design-system",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "",
   "main": "gulpfile.js",
   "engines": {

--- a/src/components/maps/_popups.scss
+++ b/src/components/maps/_popups.scss
@@ -41,6 +41,7 @@
     padding: 5px 20px 5px 5px;
     overflow-y: auto;
     line-height: 1.4;
+    word-break: break-word;
 
     &:not(:last-of-type) {
       border-bottom: 2px solid govuk-colour("light-grey");


### PR DESCRIPTION
### Description
Added workbreak to popup content to allow for wrapping of content

- Added word-break: break-word to .leaflet-popup-content

**Current:**

![image](https://user-images.githubusercontent.com/35955528/110340454-349e5580-8021-11eb-94c9-7c95592211c4.png)

**With word break:**

![image](https://user-images.githubusercontent.com/35955528/110340914-b1c9ca80-8021-11eb-897e-68c436990d5a.png)

### Checklist
- [x] Code compiles correctly
- [x] Created tests for the new changes
- [x] All tests passing
- [x] Extended the README / documentation, if necessary