### PR TITLE
chore(): update govuk-frontend to 3.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6622,9 +6622,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
-      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
+      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA==",
       "dev": true
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cz-customizable": "^6.2.0",
     "del": "^5.1.0",
     "eslint": "^6.7.0",
-    "govuk-frontend": "^3.12.0",
+    "govuk-frontend": "^3.13.0",
     "gulp": "^4.0.2",
     "gulp-better-rollup": "3.1.0",
     "gulp-concat": "^2.6.1",


### PR DESCRIPTION
### Description
Update govuk frontend to 3.13


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary