### PR TITLE
Feature/accordion

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -1,5 +1,6 @@
 import { nodeListForEach } from './common'
 import Accessibility from './core/_accessibility'
+import Accordion from './components/accordion/accordion'
 import Button from './components/button/button'
 import Calendar from './components/calendar/calendar'
 import Time from './components/time/time'
@@ -18,6 +19,11 @@ function initAll (options) {
   var $accessibility = scope.querySelectorAll('[class*="smbc-accessibility"]')
   nodeListForEach($accessibility, function ($accessibility) {
     new Accessibility($accessibility).init()
+  })
+
+  var $accordions = scope.querySelectorAll('[data-module="smbc-accordion"]')
+  nodeListForEach($accordions, function ($accordion) {
+    new Accordion($accordion).init()
   })
 
   var $buttons = scope.querySelectorAll('[data-module="govuk-button"]')
@@ -53,6 +59,7 @@ function initAll (options) {
 
 export {
   initAll,
+  Accordion,
   Button,
   FileUpload,
   MultipleFileUpload,

--- a/src/components/accordion/_index.scss
+++ b/src/components/accordion/_index.scss
@@ -1,0 +1,7 @@
+.smbc-accordion__item {
+  display: block;
+}
+
+.smbc-accordion__item--hidden {
+  display: none;
+}

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -83,9 +83,9 @@ Accordion.prototype.groupClick = function (ev) {
 Accordion.prototype.toggle = function (section) {
   var header = section.querySelector('.' + this.sectionHeaderClass)
   if (header && header.hasChildNodes) {
-    var icon,
-     children = header.childNodes
-    for (var i = 0; i < children.length; i++) {
+    var icon, i
+    var children = header.childNodes
+    for (i = 0; i < children.length; i++) {
       var child = children[i]
       if (child.nodeName === 'I') {
         icon = child.className === this.closedIcon.className ? this.openedIcon.cloneNode() : this.closedIcon.cloneNode()
@@ -101,7 +101,7 @@ Accordion.prototype.toggle = function (section) {
 
   var items = section.querySelectorAll('[class*=' + this.sectionItemClass)
   if (items) {
-    for (var i = 0; i < items.length; i++) {
+    for (i = 0; i < items.length; i++) {
       var classes = items[i].className.split(' ')
       for (var n = 0; n < classes.length; n++) {
         if (classes[n] === this.sectionItemClass) {

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1,0 +1,119 @@
+import 'govuk-frontend/govuk/vendor/polyfills/Event' // addEventListener and event.target normaliziation
+import 'govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind'
+
+function Accordion ($module) {
+  this.$module = $module
+  this.moduleId = $module.getAttribute('id')
+
+  this.collapse = true
+
+  this.hideDivClassOverride = '--hidden'
+  this.sectionHeaderClass = 'smbc-accordion__header'
+  this.sectionItemClass = 'smbc-accordion__item'
+
+  this.closedIcon = document.createElement('i')
+  this.closedIcon.className = 'fas fa-caret-square-right'
+
+  this.openedIcon = document.createElement('i')
+  this.openedIcon.className = 'fas fa-caret-square-down'
+}
+
+Accordion.prototype.init = function () {
+  console.log("Initialising Accordian")
+  if (!this.$module) {
+    return
+  }
+
+  if (this.$module.childNodes == null || this.$module.childNodes.length == 0) {
+    window.addEventListener('DOMContentLoaded', this.reInit.bind(this))
+  } else {
+    this.initSections(this.$module.childNodes)
+  }
+}
+
+Accordion.prototype.reInit = function () {
+  if (!this.$module) {
+    return
+  }
+
+  if (this.$module.childNodes != null || this.$module.childNodes.length > 0) {
+    this.initSections(this.$module.childNodes)
+  }
+}
+
+Accordion.prototype.initSections = function (sections) {
+  for (var x = 0; x < sections.length; x++) {
+    var section = sections[x]
+    if (section.hasAttribute('data-section')) {
+      var header = section.querySelector('.' + this.sectionHeaderClass)
+      if (header) {
+        var icon = this.collapse === true ? this.closedIcon.cloneNode() : this.openedIcon.cloneNode()
+        icon.addEventListener('click', this.groupClick.bind(this))
+        if (header.firstElementChild) {
+          header.firstElementChild.addEventListener('click', this.groupClick.bind(this))
+          header.insertBefore(icon, header.firstElementChild)
+        } else {
+          header.append(icon)
+        }
+      }
+      if (this.collapse === true) {
+        var items = section.querySelectorAll('.' + this.sectionItemClass)
+        if (items) {
+          for (var i = 0; i < items.length; i++) {
+            var classes = items[i].className.split(' ')
+            for (var n = 0; n < classes.length; n++) {
+              if (classes[n] == this.sectionItemClass) {
+                classes[n] += this.hideDivClassOverride
+              }
+            }
+            items[i].className = classes.join(' ')
+          }
+        }
+      }
+    }
+  }
+}
+
+Accordion.prototype.groupClick = function (ev) {
+  var section = ev.target.parentElement.parentElement
+  if (section.hasAttribute('data-section')) {
+    this.toggle(section)
+  }
+}
+
+Accordion.prototype.toggle = function (section) {
+  var header = section.querySelector('.' + this.sectionHeaderClass)
+  if (header && header.hasChildNodes) {
+    var icon,
+     children = header.childNodes
+    for (var i = 0; i < children.length; i++) {
+      var child = children[i]
+      if (child.nodeName == 'I') {
+        icon = child.className === this.closedIcon.className ? this.openedIcon.cloneNode() : this.closedIcon.cloneNode()
+        header.removeChild(child)
+      }
+    }
+    if (header.firstElementChild) {
+      header.insertBefore(icon, header.firstElementChild)
+    } else {
+      header.append(icon)
+    }
+  }
+
+  var items = section.querySelectorAll('[class*=' + this.sectionItemClass)
+  if (items) {
+    for (var i = 0; i < items.length; i++) {
+      var classes = items[i].className.split(' ')
+      for (var n = 0; n < classes.length; n++) {
+        if (classes[n] == this.sectionItemClass) {
+          classes[n] += this.hideDivClassOverride
+        } else if (classes[n] == this.sectionItemClass + this.hideDivClassOverride) {
+          classes[n] = this.sectionItemClass
+        }
+      }
+      items[i].className = classes.join(' ')
+    }
+  }
+}
+
+export default Accordion

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -23,7 +23,7 @@ Accordion.prototype.init = function () {
     return
   }
 
-  if (this.$module.childNodes == null || this.$module.childNodes.length == 0) {
+  if (this.$module.childNodes === null || this.$module.childNodes.length === 0) {
     window.addEventListener('DOMContentLoaded', this.reInit.bind(this))
   } else {
     this.initSections(this.$module.childNodes)
@@ -61,7 +61,7 @@ Accordion.prototype.initSections = function (sections) {
           for (var i = 0; i < items.length; i++) {
             var classes = items[i].className.split(' ')
             for (var n = 0; n < classes.length; n++) {
-              if (classes[n] == this.sectionItemClass) {
+              if (classes[n] === this.sectionItemClass) {
                 classes[n] += this.hideDivClassOverride
               }
             }
@@ -87,7 +87,7 @@ Accordion.prototype.toggle = function (section) {
      children = header.childNodes
     for (var i = 0; i < children.length; i++) {
       var child = children[i]
-      if (child.nodeName == 'I') {
+      if (child.nodeName === 'I') {
         icon = child.className === this.closedIcon.className ? this.openedIcon.cloneNode() : this.closedIcon.cloneNode()
         header.removeChild(child)
       }
@@ -104,9 +104,9 @@ Accordion.prototype.toggle = function (section) {
     for (var i = 0; i < items.length; i++) {
       var classes = items[i].className.split(' ')
       for (var n = 0; n < classes.length; n++) {
-        if (classes[n] == this.sectionItemClass) {
+        if (classes[n] === this.sectionItemClass) {
           classes[n] += this.hideDivClassOverride
-        } else if (classes[n] == this.sectionItemClass + this.hideDivClassOverride) {
+        } else if (classes[n] === this.sectionItemClass + this.hideDivClassOverride) {
           classes[n] = this.sectionItemClass
         }
       }

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -19,7 +19,6 @@ function Accordion ($module) {
 }
 
 Accordion.prototype.init = function () {
-  console.log("Initialising Accordian")
   if (!this.$module) {
     return
   }

--- a/src/components/maps/_controls.scss
+++ b/src/components/maps/_controls.scss
@@ -13,15 +13,32 @@
     margin-bottom: 0;
   }
 
-  .leaflet-control-layers-selector {
-    display: inline-block;
-    width: 15px;
-    margin-bottom: 0;
-  }
+  .leaflet-control-layers {
+    &-group {
+      &-label {
+        font-weight: bold;
+        cursor: pointer;
+      }
+    }
 
-  .leaflet-control-layers-toggle {
-    width: 36px !important;
-    height: 36px !important;
+    &-layer {
+      cursor: pointer;
+
+      & label {
+      display: inline-block !important;
+      }
+    }
+
+    &-selector {
+      display: inline-block;
+      width: 15px;
+      margin-bottom: 0;
+    }
+
+    &-toggle {
+      width: 36px !important;
+      height: 36px !important;
+    }
   }
 
   .leaflet-top.leaflet-left {

--- a/src/components/maps/_controls.scss
+++ b/src/components/maps/_controls.scss
@@ -25,7 +25,7 @@
       cursor: pointer;
 
       & label {
-      display: inline-block !important;
+        display: inline-block !important;
       }
     }
 


### PR DESCRIPTION
### Description
**Changes to Leaflet Controls**
  -) Overlays Group : class for a emboldened font for a group header/title and pointer cursor
  -) Overlays Layers : cursor pointer, and new "label" element to be back to an inline-block
    - only on new leaflet-control-layers-layer label, so as to not cause disruption to the "label" elements currently being display:block; for .leaflet-control-layers label
  -) slight regrouping of leaflet-control-layers

**Accordion**
  -) Rough, but working version of an "accordion", a container of sections, with header/titles and hidden/visible items
  -) I had it with more configuration being passed to it by the consuming application, but this is the simple version
 JS
  -) inti : with reInit, if the content hasn't loaded yet
  -) init sections : by adding icon to header/title and hiding "items" by default, with css class, and listener for 'click'
  -) toggle : switches class for items, and changes icon to "closed/open"
 STYLE
  -) 2 Accordion classes, for the Accordion Items to be hidden or displayed

Sure there'll be comments... happy to hear them. There's no cool transitions... wasn't really sure about the UX-y stuff to do, so decided not to bother until further instructions.

The "SMBC.Accordion" is implemented in the leaflet mapping solution, following this PR


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary