### PR TITLE
feat: Smbc panel warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smbc-design-system",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "",
   "main": "gulpfile.js",
   "engines": {

--- a/src/components/panel/_index.scss
+++ b/src/components/panel/_index.scss
@@ -16,6 +16,17 @@
   background-color: govuk-colour("smbc-green-light");
 }
 
+.smbc-panel--warning {
+  color: govuk-colour("smbc-black");
+  background-color: govuk-colour("orange");
+
+  @include govuk-media-query($media-type: print) {
+    border-color: currentColor;
+    color: $govuk-print-text-colour;
+    background: none;
+  }
+}
+
 .smbc-panel--error {
   @extend .govuk-panel--confirmation;
 


### PR DESCRIPTION
### Description
Added smbc-panel--warning for orange warning panel. Used on asset maps

![image](https://user-images.githubusercontent.com/35955528/135645502-c76a38e2-8076-470f-9862-66bd08a55c77.png)



### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary