### PR TITLE
fix(6607): add cursor & disable text highlight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smbc-design-system",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smbc-design-system",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "",
   "main": "gulpfile.js",
   "engines": {

--- a/src/components/maps/_control-layers.scss
+++ b/src/components/maps/_control-layers.scss
@@ -5,6 +5,12 @@
   border-radius: 5px;
   background: govuk-colour("white");
   box-shadow: 0 1px 5px rgba(0, 0, 0, .4); // sass-lint:disable-line no-color-literals
+  cursor: pointer;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   .smbc-control-layers__group {
     .smbc-control-layers__group-header {


### PR DESCRIPTION
### Description
In connection with [Leaflet Mapping Solution PR](https://github.com/smbc-digital/leaflet-mapping-solution/pull/31)

Fixes the "fix" for the open/close button to have a cursor of a pointer.

Adds a class to stop being able to highlight the text in the layers controls, which can cause an issue if open-closing quickly and lazily dragging.


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary