### PR TITLE
fix(notification-banner): add override to main class

### DIFF
--- a/src/components/notification-banner/index.scss
+++ b/src/components/notification-banner/index.scss
@@ -1,3 +1,11 @@
+.smbc-notification-banner {
+  @extend .govuk-notification-banner;
+
+  max-width: 950px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .smbc-notification-banner__content {
   @extend .govuk-notification-banner__content;
 


### PR DESCRIPTION
### Description
Override max-width to match the width of the green border bottom on main smbc-header_container


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary