### PR TITLE
fix(leaflet): layer controls group header nowrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smbc-design-system",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smbc-design-system",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "gulpfile.js",
   "engines": {

--- a/src/components/maps/_control-layers.scss
+++ b/src/components/maps/_control-layers.scss
@@ -15,6 +15,7 @@
   .smbc-control-layers__group {
     .smbc-control-layers__group-header {
       font-weight: $govuk-font-weight-bold;
+      white-space: nowrap;
       cursor: pointer;
 
       i {


### PR DESCRIPTION
### Description
Add nowrap for whitespace on group headers... like it has on the layers__layer ( title of individual layers without groups )... issue on mobile, currently for maps with groups that have long names... see it on UDP : https://maps.stockport.gov.uk/udp/index.html


### Checklist
- [ ] Code compiles correctly
- [ ] Created tests for the new changes
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary